### PR TITLE
Bugfix GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         contents: write
         packages: write
         pages: write
+        id-token: write
 
       environment:
         name: github-pages


### PR DESCRIPTION
Release workflow needs id-token: write for GH Pages deployment.